### PR TITLE
Scalable NAT Instances

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -91,7 +91,7 @@ resource "aws_launch_template" "this" {
       write_files : concat([
         {
           path : "/opt/nat/runonce.sh",
-          content : templatefile("${path.module}/runonce.sh", { eni_id = aws_network_interface.this.id }),
+          content : templatefile("${path.module}/runonce.sh", { sg_id = aws_security_group.this.id }),
           permissions : "0755",
         },
         {
@@ -195,7 +195,8 @@ resource "aws_iam_role_policy" "eni" {
             "Effect": "Allow",
             "Action": [
                 "ec2:AttachNetworkInterface",
-                "ec2:ModifyInstanceAttribute"
+                "ec2:ModifyInstanceAttribute",
+                "ec2:DescribeNetworkInterfaces"
             ],
             "Resource": "*"
         }

--- a/main.tf
+++ b/main.tf
@@ -194,7 +194,8 @@ resource "aws_iam_role_policy" "eni" {
         {
             "Effect": "Allow",
             "Action": [
-                "ec2:AttachNetworkInterface"
+                "ec2:AttachNetworkInterface",
+                "ec2:ModifyInstanceAttribute"
             ],
             "Resource": "*"
         }

--- a/main.tf
+++ b/main.tf
@@ -37,7 +37,7 @@ resource "aws_network_interface" "this" {
   subnet_id         = var.public_subnet
   source_dest_check = false
   description       = "ENI for NAT instance ${var.name} on route table ${var.private_route_table_ids[floor(count.index / 2)]}"
-  tags              = local.common_tags
+  tags              = merge(local.common_tags, { "half" : count.index % 2 == 0 ? "lower" : "upper" })
 }
 
 resource "aws_route" "this" {

--- a/main.tf
+++ b/main.tf
@@ -98,7 +98,7 @@ resource "aws_launch_template" "this" {
       write_files : concat([
         {
           path : "/opt/nat/runonce.sh",
-          content : templatefile("${path.module}/runonce.sh", { eni = "", sg_id = aws_security_group.this.id }),
+          content : templatefile("${path.module}/runonce.sh", { sg_id = aws_security_group.this.id }),
           permissions : "0755",
         },
         {

--- a/main.tf
+++ b/main.tf
@@ -91,7 +91,7 @@ resource "aws_launch_template" "this" {
       write_files : concat([
         {
           path : "/opt/nat/runonce.sh",
-          content : templatefile("${path.module}/runonce.sh", { sg_id = aws_security_group.this.id }),
+          content : templatefile("${path.module}/runonce.sh", { eni = "", sg_id = aws_security_group.this.id }),
           permissions : "0755",
         },
         {

--- a/main.tf
+++ b/main.tf
@@ -36,14 +36,14 @@ resource "aws_network_interface" "this" {
   security_groups   = [aws_security_group.this.id]
   subnet_id         = var.public_subnet
   source_dest_check = false
-  description       = "ENI for NAT instance ${var.name} on route table ${var.private_route_table_ids[ceil(count.index / 2)]}"
+  description       = "ENI for NAT instance ${var.name} on route table ${var.private_route_table_ids[ceil((count.index / 2))]}"
   tags              = local.common_tags
 }
 
 resource "aws_route" "this" {
   count = local.interface_count
 
-  route_table_id         = var.private_route_table_ids[ceil(count.index / 2)]
+  route_table_id         = var.private_route_table_ids[ceil((count.index / 2))]
   destination_cidr_block = local.interface_cidrs[count.index]
   network_interface_id   = aws_network_interface.this[count.index].id
 }

--- a/main.tf
+++ b/main.tf
@@ -110,7 +110,9 @@ resource "aws_launch_template" "this" {
         },
         {
           path : "/opt/nat/snat.sh",
-          content : file("${path.module}/snat.sh"),
+          content : templatefile("${path.module}/snat.sh", {
+            routes_count = length(var.routes)
+          }),
           permissions : "0755",
         },
         {

--- a/main.tf
+++ b/main.tf
@@ -41,7 +41,7 @@ resource "aws_network_interface" "this" {
 }
 
 resource "aws_route" "this" {
-  count = local.interface_count
+  count = var.dry_run ? 0 : local.interface_count
 
   route_table_id         = var.private_route_table_ids[floor(count.index / 2)]
   destination_cidr_block = local.interface_cidrs[count.index]

--- a/main.tf
+++ b/main.tf
@@ -36,14 +36,14 @@ resource "aws_network_interface" "this" {
   security_groups   = [aws_security_group.this.id]
   subnet_id         = var.public_subnet
   source_dest_check = false
-  description       = "ENI for NAT instance ${var.name} on route table ${var.private_route_table_ids[ceil((count.index / 2))]}"
+  description       = "ENI for NAT instance ${var.name} on route table ${var.private_route_table_ids[floor(count.index / 2)]}"
   tags              = local.common_tags
 }
 
 resource "aws_route" "this" {
   count = local.interface_count
 
-  route_table_id         = var.private_route_table_ids[ceil((count.index / 2))]
+  route_table_id         = var.private_route_table_ids[floor(count.index / 2)]
   destination_cidr_block = local.interface_cidrs[count.index]
   network_interface_id   = aws_network_interface.this[count.index].id
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,8 @@
+output "asg" {
+  description = "The Autoscaling Group provisioning NAT instances"
+  value       = aws_autoscaling_group.this
+}
+
 output "eni_ids" {
   description = "List of ENI IDs for the NAT instances"
   value       = [for i in aws_network_interface.this : i.id]

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
-output "eni_id" {
-  description = "ID of the ENI for the NAT instance"
-  value       = aws_network_interface.this.id
+output "eni_ids" {
+  description = "List of ENI IDs for the NAT instances"
+  value       = [for i in aws_network_interface.this : i.id]
 }
 
 output "eni_private_ips" {
@@ -10,11 +10,11 @@ output "eni_private_ips" {
 }
 
 output "sg_id" {
-  description = "ID of the security group of the NAT instance"
+  description = "ID of the security group of the NAT instances"
   value       = aws_security_group.this.id
 }
 
 output "iam_role_name" {
-  description = "Name of the IAM role for the NAT instance"
+  description = "Name of the IAM role for the NAT instances"
   value       = aws_iam_role.this.name
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,10 +3,10 @@ output "eni_id" {
   value       = aws_network_interface.this.id
 }
 
-output "eni_private_ip" {
-  description = "Private IP of the ENI for the NAT instance"
+output "eni_private_ips" {
+  description = "Private IPs of the ENI for the NAT instance"
   # workaround of https://github.com/terraform-providers/terraform-provider-aws/issues/7522
-  value = tolist(aws_network_interface.this.private_ips)[0]
+  value = flatten([for i in aws_network_interface.this : tolist(i.private_ips)])
 }
 
 output "sg_id" {

--- a/runonce.sh
+++ b/runonce.sh
@@ -21,7 +21,7 @@ for i in {1..2}; do
         aws ec2 attach-network-interface \
           --region "$(/opt/aws/bin/ec2-metadata -z  | sed 's/placement: \(.*\).$/\1/')" \
           --instance-id "$(/opt/aws/bin/ec2-metadata -i | cut -d' ' -f2)" \
-          --device-index 1 \
+          --device-index $i \
           --network-interface-id $eni
         return_code=$?
     done

--- a/runonce.sh
+++ b/runonce.sh
@@ -1,6 +1,5 @@
 #!/bin/bash -x
 
-eni=""
 return_code=1
 
 

--- a/runonce.sh
+++ b/runonce.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -x
 
 return_code=1
-
+tag="lower"
 
 aws ec2 modify-instance-attribute --no-source-dest-check \
   --region "$(/opt/aws/bin/ec2-metadata -z  | sed 's/placement: \(.*\).$/\1/')" \
@@ -14,7 +14,7 @@ for i in {1..2}; do
         # get the first (random) available interface
         eni=$(aws ec2 describe-network-interfaces \
           --region "$(/opt/aws/bin/ec2-metadata -z  | sed 's/placement: \(.*\).$/\1/')" \
-          --filters "Name=group-id,Values=${sg_id}" "Name=status,Values=available" \
+          --filters "Name=group-id,Values=${sg_id}" "Name=tag:half,Values=${tag}" "Name=status,Values=available" \
           --query 'NetworkInterfaces[0].NetworkInterfaceId' | tr -d '"')
 
         # attach the ENI
@@ -26,6 +26,7 @@ for i in {1..2}; do
         return_code=$?
     done
     return_code=1
+    tag="upper"
 done
 
 

--- a/runonce.sh
+++ b/runonce.sh
@@ -1,5 +1,10 @@
 #!/bin/bash -x
 
+
+aws ec2 modify-instance-attribute --no-source-dest-check \
+  --region "$(/opt/aws/bin/ec2-metadata -z  | sed 's/placement: \(.*\).$/\1/')" \
+  --instance-id "$(/opt/aws/bin/ec2-metadata -i | cut -d' ' -f2)"
+
 # attach the ENI
 aws ec2 attach-network-interface \
   --region "$(/opt/aws/bin/ec2-metadata -z  | sed 's/placement: \(.*\).$/\1/')" \

--- a/runonce.sh
+++ b/runonce.sh
@@ -1,5 +1,6 @@
 #!/bin/bash -x
 
+eni=""
 return_code=1
 
 

--- a/runonce.sh
+++ b/runonce.sh
@@ -3,24 +3,27 @@
 return_code=1
 tags=${tags}
 
-aws ec2 modify-instance-attribute --no-source-dest-check \
-  --region "$(/opt/aws/bin/ec2-metadata -z  | sed 's/placement: \(.*\).$/\1/')" \
-  --instance-id "$(/opt/aws/bin/ec2-metadata -i | cut -d' ' -f2)"
+region=$(/opt/aws/bin/ec2-metadata -z  | sed 's/placement: \(.*\).$/\1/')
+instance_id=$(/opt/aws/bin/ec2-metadata -i | cut -d' ' -f2)
 
-# attach 2 interfaces for maximal bandwidth
+aws ec2 modify-instance-attribute --no-source-dest-check \
+  --region "$region" \
+  --instance-id "$instance_id"
+
+# attach one interface for each route
 for i in {1..${routes_count}}; do
     # retry attachment errors in case of contention
-    while [ $return_code -ne 0 ]; do
+    while (( return_code )); do
         # get the first (random) available interface
         eni=$(aws ec2 describe-network-interfaces \
-          --region "$(/opt/aws/bin/ec2-metadata -z  | sed 's/placement: \(.*\).$/\1/')" \
-          --filters "Name=group-id,Values=${sg_id}" "Name=tag:route,Values=$tags[$i]" "Name=status,Values=available" \
+          --region "$region" \
+          --filters "Name=group-id,Values=${sg_id}" "Name=tag:route,Values=${tags[i]}" "Name=status,Values=available" \
           --query 'NetworkInterfaces[0].NetworkInterfaceId' | tr -d '"')
 
         # attach the ENI
         aws ec2 attach-network-interface \
-          --region "$(/opt/aws/bin/ec2-metadata -z  | sed 's/placement: \(.*\).$/\1/')" \
-          --instance-id "$(/opt/aws/bin/ec2-metadata -i | cut -d' ' -f2)" \
+          --region "$region" \
+          --instance-id "$instance_id" \
           --device-index $i \
           --network-interface-id $eni
         return_code=$?

--- a/runonce.sh
+++ b/runonce.sh
@@ -17,7 +17,7 @@ for i in {1..${routes_count}}; do
         # get the first (random) available interface
         eni=$(aws ec2 describe-network-interfaces \
           --region "$region" \
-          --filters "Name=group-id,Values=${sg_id}" "Name=tag:route,Values=$${tags[i]}" "Name=status,Values=available" \
+          --filters "Name=group-id,Values=${sg_id}" "Name=tag:route,Values=$${tags[i-1]}" "Name=status,Values=available" \
           --query 'NetworkInterfaces[0].NetworkInterfaceId' | tr -d '"')
 
         # attach the ENI

--- a/runonce.sh
+++ b/runonce.sh
@@ -13,7 +13,7 @@ while [ $return_code -ne 0 ]; do
     eni=$(aws ec2 describe-network-interfaces \
       --region "$(/opt/aws/bin/ec2-metadata -z  | sed 's/placement: \(.*\).$/\1/')" \
       --filters "Name=group-id,Values=${sg_id}" "Name=status,Values=available" \
-      --query 'NetworkInterfaces[0].NetworkInterfaceId')
+      --query 'NetworkInterfaces[0].NetworkInterfaceId' | tr -d '"')
 
     # attach the ENI
     aws ec2 attach-network-interface \

--- a/runonce.sh
+++ b/runonce.sh
@@ -1,16 +1,29 @@
 #!/bin/bash -x
 
+return_code=1
+
 
 aws ec2 modify-instance-attribute --no-source-dest-check \
   --region "$(/opt/aws/bin/ec2-metadata -z  | sed 's/placement: \(.*\).$/\1/')" \
   --instance-id "$(/opt/aws/bin/ec2-metadata -i | cut -d' ' -f2)"
 
-# attach the ENI
-aws ec2 attach-network-interface \
-  --region "$(/opt/aws/bin/ec2-metadata -z  | sed 's/placement: \(.*\).$/\1/')" \
-  --instance-id "$(/opt/aws/bin/ec2-metadata -i | cut -d' ' -f2)" \
-  --device-index 1 \
-  --network-interface-id "${eni_id}"
+# retry attachment errors in case of contention
+while [ $return_code -ne 0 ]; do
+    # get the first (random) available interface
+    eni=$(aws ec2 describe-network-interfaces \
+      --region "$(/opt/aws/bin/ec2-metadata -z  | sed 's/placement: \(.*\).$/\1/')" \
+      --filters "Name=group-id,Values=${sg_id}" "Name=attachment.delete-on-termination,Values=false" "Name=status,Values=available" \
+      --query 'NetworkInterfaces[0].NetworkInterfaceId')
+
+    # attach the ENI
+    aws ec2 attach-network-interface \
+      --region "$(/opt/aws/bin/ec2-metadata -z  | sed 's/placement: \(.*\).$/\1/')" \
+      --instance-id "$(/opt/aws/bin/ec2-metadata -i | cut -d' ' -f2)" \
+      --device-index 1 \
+      --network-interface-id "${eni}"
+    return_code=$?
+done
+
 
 # start SNAT
 systemctl enable snat

--- a/runonce.sh
+++ b/runonce.sh
@@ -12,7 +12,7 @@ while [ $return_code -ne 0 ]; do
     # get the first (random) available interface
     eni=$(aws ec2 describe-network-interfaces \
       --region "$(/opt/aws/bin/ec2-metadata -z  | sed 's/placement: \(.*\).$/\1/')" \
-      --filters "Name=group-id,Values=${sg_id}" "Name=attachment.delete-on-termination,Values=false" "Name=status,Values=available" \
+      --filters "Name=group-id,Values=${sg_id}" "Name=status,Values=available" \
       --query 'NetworkInterfaces[0].NetworkInterfaceId')
 
     # attach the ENI

--- a/runonce.sh
+++ b/runonce.sh
@@ -20,7 +20,7 @@ while [ $return_code -ne 0 ]; do
       --region "$(/opt/aws/bin/ec2-metadata -z  | sed 's/placement: \(.*\).$/\1/')" \
       --instance-id "$(/opt/aws/bin/ec2-metadata -i | cut -d' ' -f2)" \
       --device-index 1 \
-      --network-interface-id "${eni}"
+      --network-interface-id $eni
     return_code=$?
 done
 

--- a/runonce.sh
+++ b/runonce.sh
@@ -25,6 +25,7 @@ for i in {1..2}; do
           --network-interface-id $eni
         return_code=$?
     done
+    return_code=1
 done
 
 

--- a/runonce.sh
+++ b/runonce.sh
@@ -14,7 +14,7 @@ for i in {1..2}; do
         # get the first (random) available interface
         eni=$(aws ec2 describe-network-interfaces \
           --region "$(/opt/aws/bin/ec2-metadata -z  | sed 's/placement: \(.*\).$/\1/')" \
-          --filters "Name=group-id,Values=${sg_id}" "Name=tag:half,Values=${tag}" "Name=status,Values=available" \
+          --filters "Name=group-id,Values=${sg_id}" "Name=tag:half,Values=$tag" "Name=status,Values=available" \
           --query 'NetworkInterfaces[0].NetworkInterfaceId' | tr -d '"')
 
         # attach the ENI

--- a/runonce.sh
+++ b/runonce.sh
@@ -1,20 +1,20 @@
 #!/bin/bash -x
 
 return_code=1
-tag="lower"
+tags=${tags}
 
 aws ec2 modify-instance-attribute --no-source-dest-check \
   --region "$(/opt/aws/bin/ec2-metadata -z  | sed 's/placement: \(.*\).$/\1/')" \
   --instance-id "$(/opt/aws/bin/ec2-metadata -i | cut -d' ' -f2)"
 
 # attach 2 interfaces for maximal bandwidth
-for i in {1..2}; do
+for i in {1..${routes_count}}; do
     # retry attachment errors in case of contention
     while [ $return_code -ne 0 ]; do
         # get the first (random) available interface
         eni=$(aws ec2 describe-network-interfaces \
           --region "$(/opt/aws/bin/ec2-metadata -z  | sed 's/placement: \(.*\).$/\1/')" \
-          --filters "Name=group-id,Values=${sg_id}" "Name=tag:half,Values=$tag" "Name=status,Values=available" \
+          --filters "Name=group-id,Values=${sg_id}" "Name=tag:route,Values=$tags[$i]" "Name=status,Values=available" \
           --query 'NetworkInterfaces[0].NetworkInterfaceId' | tr -d '"')
 
         # attach the ENI
@@ -26,7 +26,6 @@ for i in {1..2}; do
         return_code=$?
     done
     return_code=1
-    tag="upper"
 done
 
 

--- a/runonce.sh
+++ b/runonce.sh
@@ -17,7 +17,7 @@ for i in {1..${routes_count}}; do
         # get the first (random) available interface
         eni=$(aws ec2 describe-network-interfaces \
           --region "$region" \
-          --filters "Name=group-id,Values=${sg_id}" "Name=tag:route,Values=${tags[i]}" "Name=status,Values=available" \
+          --filters "Name=group-id,Values=${sg_id}" "Name=tag:route,Values=$${tags[i]}" "Name=status,Values=available" \
           --query 'NetworkInterfaces[0].NetworkInterfaceId' | tr -d '"')
 
         # attach the ENI

--- a/runonce.sh
+++ b/runonce.sh
@@ -7,21 +7,24 @@ aws ec2 modify-instance-attribute --no-source-dest-check \
   --region "$(/opt/aws/bin/ec2-metadata -z  | sed 's/placement: \(.*\).$/\1/')" \
   --instance-id "$(/opt/aws/bin/ec2-metadata -i | cut -d' ' -f2)"
 
-# retry attachment errors in case of contention
-while [ $return_code -ne 0 ]; do
-    # get the first (random) available interface
-    eni=$(aws ec2 describe-network-interfaces \
-      --region "$(/opt/aws/bin/ec2-metadata -z  | sed 's/placement: \(.*\).$/\1/')" \
-      --filters "Name=group-id,Values=${sg_id}" "Name=status,Values=available" \
-      --query 'NetworkInterfaces[0].NetworkInterfaceId' | tr -d '"')
+# attach 2 interfaces for maximal bandwidth
+for i in {1..2}; do
+    # retry attachment errors in case of contention
+    while [ $return_code -ne 0 ]; do
+        # get the first (random) available interface
+        eni=$(aws ec2 describe-network-interfaces \
+          --region "$(/opt/aws/bin/ec2-metadata -z  | sed 's/placement: \(.*\).$/\1/')" \
+          --filters "Name=group-id,Values=${sg_id}" "Name=status,Values=available" \
+          --query 'NetworkInterfaces[0].NetworkInterfaceId' | tr -d '"')
 
-    # attach the ENI
-    aws ec2 attach-network-interface \
-      --region "$(/opt/aws/bin/ec2-metadata -z  | sed 's/placement: \(.*\).$/\1/')" \
-      --instance-id "$(/opt/aws/bin/ec2-metadata -i | cut -d' ' -f2)" \
-      --device-index 1 \
-      --network-interface-id $eni
-    return_code=$?
+        # attach the ENI
+        aws ec2 attach-network-interface \
+          --region "$(/opt/aws/bin/ec2-metadata -z  | sed 's/placement: \(.*\).$/\1/')" \
+          --instance-id "$(/opt/aws/bin/ec2-metadata -i | cut -d' ' -f2)" \
+          --device-index 1 \
+          --network-interface-id $eni
+        return_code=$?
+    done
 done
 
 

--- a/snat.sh
+++ b/snat.sh
@@ -5,13 +5,16 @@ while ! ip link show dev eth1; do
   sleep 1
 done
 
+sysctl -q -w net.ipv4.conf.all.rp_filter=0
+sysctl -q -w net.ipv4.conf.eth0.rp_filter=0
+sysctl -q -w net.ipv4.conf.eth1.rp_filter=0
+sysctl -q -w net.ipv4.conf.default.rp_filter=0
+
+
 # enable IP forwarding and NAT
 sysctl -q -w net.ipv4.ip_forward=1
 sysctl -q -w net.ipv4.conf.eth1.send_redirects=0
-iptables -t nat -A POSTROUTING -o eth1 -j MASQUERADE
-
-# switch the default route to eth1
-ip route del default dev eth0
+iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
 
 # wait for network connection
 curl --retry 10 http://www.example.com

--- a/snat.sh
+++ b/snat.sh
@@ -1,19 +1,21 @@
 #!/bin/bash -x
 
-# wait for eth1
-while ! ip link show dev eth1; do
-  sleep 1
+for i in {0..${routes_count}}; do
+    # wait for interface
+    while ! ip link show dev eth$i; do
+      sleep 1
+    done
+
+    sysctl -q -w net.ipv4.conf.eth$i.rp_filter=0
+
+    # enable IP forwarding and NAT
+    sysctl -q -w net.ipv4.conf.eth$i.send_redirects=0
 done
 
 sysctl -q -w net.ipv4.conf.all.rp_filter=0
-sysctl -q -w net.ipv4.conf.eth0.rp_filter=0
-sysctl -q -w net.ipv4.conf.eth1.rp_filter=0
 sysctl -q -w net.ipv4.conf.default.rp_filter=0
-
-
-# enable IP forwarding and NAT
 sysctl -q -w net.ipv4.ip_forward=1
-sysctl -q -w net.ipv4.conf.eth1.send_redirects=0
+
 iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
 
 # wait for network connection

--- a/variables.tf
+++ b/variables.tf
@@ -21,12 +21,12 @@ variable "public_subnet" {
 
 variable "private_subnets_cidr_blocks" {
   description = "List of CIDR blocks of the private subnets. The NAT instance accepts connections from this subnets"
-  type        = list
+  type        = list(any)
 }
 
 variable "private_route_table_ids" {
   description = "List of ID of the route tables for the private subnets. You can set this to assign the each default route to the NAT instance"
-  type        = list
+  type        = list(any)
   default     = []
 }
 
@@ -38,7 +38,7 @@ variable "image_id" {
 
 variable "instance_types" {
   description = "Candidates of spot instance type for the NAT instance. This is used in the mixed instances policy"
-  type        = list
+  type        = list(any)
   default     = ["t3.nano", "t3a.nano"]
 }
 
@@ -56,19 +56,19 @@ variable "key_name" {
 
 variable "tags" {
   description = "Tags applied to resources created with this module"
-  type        = map
+  type        = map(any)
   default     = {}
 }
 
 variable "user_data_write_files" {
   description = "Additional write_files section of cloud-init"
-  type        = list
+  type        = list(any)
   default     = []
 }
 
 variable "user_data_runcmd" {
   description = "Additional runcmd section of cloud-init"
-  type        = list
+  type        = list(any)
   default     = []
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -36,6 +36,12 @@ variable "private_route_table_ids" {
   default     = []
 }
 
+variable "routes" {
+  description = "List of CIDRs to break each private subnet into. Caution: this must not exceed the ENI capacity of the provisioned EC2 instance types."
+  type        = list(string)
+  default     = ["0.0.0.0/1", "128.0.0.0/1"]
+}
+
 variable "image_id" {
   description = "AMI of the NAT instance. Default to the latest Amazon Linux 2"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,12 @@ variable "enabled" {
   default     = true
 }
 
+variable "dry_run" {
+  description = "Use this flag for safely standing up resources without applying any route changes. Useful for transitioning existing environments from NAT Gateway."
+  type        = bool
+  default     = false
+}
+
 variable "name" {
   description = "Name for all the resources as identifier"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -45,7 +45,7 @@ variable "image_id" {
 variable "instance_types" {
   description = "Candidates of spot instance type for the NAT instance. This is used in the mixed instances policy"
   type        = list(any)
-  default     = ["t3.nano", "t3a.nano"]
+  default     = ["t3.medium", "t3a.medium"]
 }
 
 variable "use_spot_instance" {


### PR DESCRIPTION
This repo is a fork of a fork, but with this PR I've adapted it to our needs.

- Create `n` NAT instances corresponding to `n` private subnets under an autoscaling group
- Create 2 ENIs for every NAT instance and split each subnet into two routes pointing at these ENIs
- Added a `dry_run` option for standing up all infrastructure without generating routes. This makes it easier to safely transition existing environments off of NAT Gateway.

Successfully load tested this configuration to 7M RPM on 6 subnets. In practice I think the ceiling is even higher than this.

#### Future work:
- It would be simple to bounce detached ENIs from failed instances over to other instances for fault tolerance, but we would need a way of moving them back over when new instances come back up.
- Scale-in/scale-out support
- Even greater scale could be achieved with larger instances and more ENIs. This could either be configurable or dynamic based on autoscaling.